### PR TITLE
Add callback mode to VideoStreamConsumer.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ option(ENABLE_SANITIZE "Sanitize tool" OFF)
 option(ENABLE_SECURITY "Security Ford protocol protection" ON)
 option(ENABLE_HMI_PTU_DECRYPTION "Policy table update parsed by hmi" ON)
 
-option(BUILD_TARGET_LIBRARY    "build target as library" OFF)
+option(BUILD_TARGET_LIBRARY    "build target as library" ON)
 
 set(OS_TYPE_OPTION 	"$ENV{OS_TYPE}")
 set(DEBUG_OPTION 	"$ENV{DEBUG}")

--- a/src/appMain/smartDeviceLink.ini
+++ b/src/appMain/smartDeviceLink.ini
@@ -98,6 +98,8 @@ AudioStreamConsumer = socket
 ;AudioStreamConsumer = file
 ;VideoStreamConsumer = pipe
 ;AudioStreamConsumer = pipe
+;VideoStreamConsumer = callback
+;AudioStreamConsumer = callback
 ; Temp solution: if you change NamedPipePath also change path to pipe in src/components/qt_hmi/qml_model_qtXX/views/SDLNavi.qml
 ; Named pipe path will be constructed using AppStorageFolder + name
 NamedVideoPipePath = video_stream_pipe

--- a/src/components/media_manager/include/media_manager/callback_streamer_adapter.h
+++ b/src/components/media_manager/include/media_manager/callback_streamer_adapter.h
@@ -42,7 +42,9 @@ namespace media_manager {
 class CallbackStreamerAdapter : public StreamerAdapter {
  public:
   CallbackStreamerAdapter();
-  virtual ~CallbackStreamerAdapter();
+	virtual ~CallbackStreamerAdapter();
+	virtual void SendData(int32_t application_key,
+		const ::protocol_handler::RawMessagePtr msg);
 
  protected:
   class CallbackStreamer : public StreamerAdapter::Streamer {

--- a/src/components/media_manager/src/callback_streamer_adapter.cc
+++ b/src/components/media_manager/src/callback_streamer_adapter.cc
@@ -60,10 +60,19 @@ void CallbackStreamerAdapter::CallbackStreamer::Disconnect() {
   
 }
 
+void CallbackStreamerAdapter::SendData(int32_t application_key,
+	const ::protocol_handler::RawMessagePtr msg) {
+	if (!is_app_performing_activity(application_key)) {
+		return;
+	}
+#ifdef BUILD_TARGET_LIB
+	s_mediaVideoStreamSendCallback((const char *)msg->data(), msg.get()->data_size());
+#endif
+}
+
 bool CallbackStreamerAdapter::CallbackStreamer::Send(
     protocol_handler::RawMessagePtr msg) {
   LOG4CXX_AUTO_TRACE(logger_);
-  printf("%s, Line:%d\n", __FUNCTION__, __LINE__);
 #ifdef BUILD_TARGET_LIB
   s_mediaVideoStreamSendCallback((const char *)msg->data(), msg.get()->data_size());
 #endif


### PR DESCRIPTION
During the process of data transmission, the transmission break off suddenly. We use call back mode to solve this issue.
Please modify smartDeviceLink.ini to config correctly to use callback mode. Set like this:
    VideoStreamConsumer = callback
    AudioStreamConsumer = callback

We have given release version on https://github.com/VENGEL/sdl_bin_release.git, please use it to do some test if necessary.